### PR TITLE
Support encoding of binary "bytes" fields

### DIFF
--- a/pb2json.cpp
+++ b/pb2json.cpp
@@ -1,6 +1,21 @@
 #include "pb2json.h"
 
 using std::string;
+string hex_encode(const string& input)
+{
+	static const char* const lut = "0123456789abcdef";
+	size_t len = input.length();
+
+	std::string output;
+	output.reserve(2 * len);
+	for (size_t i = 0; i < len; ++i)
+	{
+		const unsigned char c = input[i];
+		output.push_back(lut[c >> 4]);
+		output.push_back(lut[c & 15]);
+	}
+	return output;
+}
 char * pb2json(const Message &msg)
 {
 	json_t *root = parse_msg(&msg);
@@ -158,11 +173,14 @@ static json_t *parse_msg(const Message *msg)
 					break;
 				case FieldDescriptor::CPPTYPE_BOOL:
 					value7 = ref->GetBool(*msg,field);
-
 					json_object_set_new(root,name,value7?json_true():json_false())	;
 					break;
 				case FieldDescriptor::CPPTYPE_STRING:
-					value8 = ref->GetString(*msg,field);
+					if (field->type() == FieldDescriptor::TYPE_BYTES) {
+						value8 = hex_encode(ref->GetString(*msg,field));
+					} else {
+						value8 = ref->GetString(*msg,field);
+					}
 					json_object_set_new(root,name,json_string(value8.c_str()));	
 					break;
 				case FieldDescriptor::CPPTYPE_MESSAGE:


### PR DESCRIPTION
protobufs internally treat these fields as strings, but jansson hickups on trying to convert arbitrary binary into a string, and silently discards the field. 

This patch adds a simple wrapper that hex-encodes the that if the field is of TYPE_BYTES. This way, the JSON is printable, and binary bytes fields can be preserved (although they will have to be re-encoded if ever put back into a protobuf).
