### PR TITLE
Removed dependencies on namespace std

### DIFF
--- a/pb2json.cpp
+++ b/pb2json.cpp
@@ -1,7 +1,7 @@
 #include "pb2json.h"
 
-using std::string;
-string hex_encode(const string& input)
+//using std::string;
+std::string hex_encode(const std::string& input)
 {
 	static const char* const lut = "0123456789abcdef";
 	size_t len = input.length();
@@ -16,17 +16,17 @@ string hex_encode(const string& input)
 	}
 	return output;
 }
-char * pb2json(const Message &msg)
+char * pb2json(const google::protobuf::Message &msg)
 {
 	json_t *root = parse_msg(&msg);
 	char *json = json_dumps(root,0);
 	json_decref(root);
 	return json; // should be freed by caller
 }
-char * pb2json( Message *msg,const char *buf ,int len)
+char * pb2json( google::protobuf::Message *msg,const char *buf ,int len)
 {
 	GOOGLE_PROTOBUF_VERIFY_VERSION;
-	string s (buf,len);
+	std::string s (buf,len);
 	msg->ParseFromString(s);
 	json_t *root = parse_msg(msg);
 	char *json = json_dumps(root,0);
@@ -34,80 +34,80 @@ char * pb2json( Message *msg,const char *buf ,int len)
 	google::protobuf::ShutdownProtobufLibrary();
 	return json; // should be freed by caller
 }
-static json_t *parse_repeated_field(const Message *msg,const Reflection * ref,const FieldDescriptor *field)
+static json_t *parse_repeated_field(const google::protobuf::Message *msg,const google::protobuf::Reflection * ref,const google::protobuf::FieldDescriptor *field)
 {
 	size_t count = ref->FieldSize(*msg,field);
 	json_t *arr = json_array();	
 	if(!arr)return NULL;
 	switch(field->cpp_type())	
 	{
-		case FieldDescriptor::CPPTYPE_DOUBLE:
+		case google::protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
 				double	value1 = ref->GetRepeatedDouble(*msg,field,i);
 				json_array_append_new(arr,json_real(value1));	
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_FLOAT:
+		case google::protobuf::FieldDescriptor::CPPTYPE_FLOAT:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
 				float value2 = ref->GetRepeatedFloat(*msg,field,i);
 				json_array_append_new(arr,json_real(value2));	
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_INT64:
+		case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
 				int64_t value3 = ref->GetRepeatedInt64(*msg,field,i);
 				json_array_append_new(arr,json_integer(value3))	;
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_UINT64:
+		case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
 				uint64_t value4 = ref->GetRepeatedUInt64(*msg,field,i);
 				json_array_append_new(arr,json_integer(value4));	
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_INT32:
+		case google::protobuf::FieldDescriptor::CPPTYPE_INT32:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
 				int32_t value5 = ref->GetRepeatedInt32(*msg,field,i);
 				json_array_append_new(arr,json_integer(value5));	
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_UINT32:
+		case google::protobuf::FieldDescriptor::CPPTYPE_UINT32:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
 				uint32_t value6 = ref->GetRepeatedUInt32(*msg,field,i);
 				json_array_append_new(arr,json_integer(value6));	
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_BOOL:
+		case google::protobuf::FieldDescriptor::CPPTYPE_BOOL:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
 				bool value7 = ref->GetRepeatedBool(*msg,field,i);
 				json_array_append_new(arr,value7?json_true():json_false())	;
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_STRING:
+		case google::protobuf::FieldDescriptor::CPPTYPE_STRING:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
-				string value8 = ref->GetRepeatedString(*msg,field,i);
+				std::string value8 = ref->GetRepeatedString(*msg,field,i);
 				json_array_append_new(arr,json_string(value8.c_str()));	
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_MESSAGE:
+		case google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
-				const Message *value9 = &(ref->GetRepeatedMessage(*msg,field,i));
+				const google::protobuf::Message *value9 = &(ref->GetRepeatedMessage(*msg,field,i));
 				json_array_append_new(arr,parse_msg(value9));
 			}
 			break;
-		case FieldDescriptor::CPPTYPE_ENUM:
+		case google::protobuf::FieldDescriptor::CPPTYPE_ENUM:
 			for(size_t i = 0 ; i != count ; ++i)
 			{
-				const EnumValueDescriptor* value10 = ref->GetRepeatedEnum(*msg,field,i);
+				const google::protobuf::EnumValueDescriptor* value10 = ref->GetRepeatedEnum(*msg,field,i);
 				json_array_append_new(arr,json_integer(value10->number()));	
 			}
 			break;
@@ -116,19 +116,19 @@ static json_t *parse_repeated_field(const Message *msg,const Reflection * ref,co
 	}
 	return arr;
 }
-static json_t *parse_msg(const Message *msg)
+static json_t *parse_msg(const google::protobuf::Message *msg)
 {
-	const Descriptor *d = msg->GetDescriptor();
+	const google::protobuf::Descriptor *d = msg->GetDescriptor();
 	if(!d)return NULL;
 	size_t count = d->field_count();
 	json_t *root = json_object();
 	if(!root)return NULL;
 	for (size_t i = 0; i != count ; ++i)
 	{
-		const FieldDescriptor *field = d->field(i);
+		const google::protobuf::FieldDescriptor *field = d->field(i);
 		if(!field)return NULL;
 
-		const Reflection *ref = msg->GetReflection();
+		const google::protobuf::Reflection *ref = msg->GetReflection();
 		if(!ref)return NULL;
 		const char *name = field->name().c_str();
 		if(field->is_repeated())
@@ -143,53 +143,53 @@ static json_t *parse_msg(const Message *msg)
 			int32_t value5;
 			uint32_t value6;
 			bool value7;
-			string value8;
-			const Message *value9;
-			const EnumValueDescriptor *value10;
+			std::string value8;
+			const google::protobuf::Message *value9;
+			const google::protobuf::EnumValueDescriptor *value10;
 
 			switch (field->cpp_type())
 			{
-				case FieldDescriptor::CPPTYPE_DOUBLE:
+				case google::protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
 					value1 = ref->GetDouble(*msg,field);
 					json_object_set_new(root,name,json_real(value1));	
 					break;
-				case FieldDescriptor::CPPTYPE_FLOAT:
+				case google::protobuf::FieldDescriptor::CPPTYPE_FLOAT:
 					value2 = ref->GetFloat(*msg,field);
 					json_object_set_new(root,name,json_real(value2));	
 					break;
-				case FieldDescriptor::CPPTYPE_INT64:
+				case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
 					value3 = ref->GetInt64(*msg,field);
 					json_object_set_new(root,name,json_integer(value3))	;
 					break;
-				case FieldDescriptor::CPPTYPE_UINT64:
+				case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
 					value4 = ref->GetUInt64(*msg,field);
 					json_object_set_new(root,name,json_integer(value4));	
 					break;
-				case FieldDescriptor::CPPTYPE_INT32:
+				case google::protobuf::FieldDescriptor::CPPTYPE_INT32:
 					value5 = ref->GetInt32(*msg,field);
 					json_object_set_new(root,name,json_integer(value5));	
 					break;
-				case FieldDescriptor::CPPTYPE_UINT32:
+				case google::protobuf::FieldDescriptor::CPPTYPE_UINT32:
 					value6 = ref->GetUInt32(*msg,field);
 					json_object_set_new(root,name,json_integer(value6));	
 					break;
-				case FieldDescriptor::CPPTYPE_BOOL:
+				case google::protobuf::FieldDescriptor::CPPTYPE_BOOL:
 					value7 = ref->GetBool(*msg,field);
 					json_object_set_new(root,name,value7?json_true():json_false())	;
 					break;
-				case FieldDescriptor::CPPTYPE_STRING:
-					if (field->type() == FieldDescriptor::TYPE_BYTES) {
+				case google::protobuf::FieldDescriptor::CPPTYPE_STRING:
+					if (field->type() == google::protobuf::FieldDescriptor::TYPE_BYTES) {
 						value8 = hex_encode(ref->GetString(*msg,field));
 					} else {
 						value8 = ref->GetString(*msg,field);
 					}
 					json_object_set_new(root,name,json_string(value8.c_str()));	
 					break;
-				case FieldDescriptor::CPPTYPE_MESSAGE:
+				case google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
 					value9 = &(ref->GetMessage(*msg,field));
 					json_object_set_new(root,name,parse_msg(value9));
 					break;
-				case FieldDescriptor::CPPTYPE_ENUM:
+				case google::protobuf::FieldDescriptor::CPPTYPE_ENUM:
 					value10 = ref->GetEnum(*msg,field);
 					json_object_set_new(root,name,json_integer(value10->number()));	
 					break;

--- a/pb2json.h
+++ b/pb2json.h
@@ -2,8 +2,8 @@
 #include <string>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
-using namespace google::protobuf;
-char *pb2json(const Message &msg);
-char *pb2json(Message *msg,const char *buf,int len);
-static json_t *parse_msg(const Message *msg);
-static json_t *parse_repeated_field(const Message *msg,const Reflection * ref,const FieldDescriptor *field);
+//using namespace google::protobuf;
+char *pb2json(const google::protobuf::Message &msg);
+char *pb2json(google::protobuf::Message *msg,const char *buf,int len);
+static json_t *parse_msg(const google::protobuf::Message *msg);
+static json_t *parse_repeated_field(const google::protobuf::Message *msg,const google::protobuf::Reflection * ref,const google::protobuf::FieldDescriptor *field);

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -16,7 +16,7 @@ int main(int argc,char *argv[])
 	char *buf = new char [len];
 
 	fin.read(buf,len);
-	Message *p = new Person();
+	google::protobuf::Message *p = new Person();
 	char *json = pb2json(p,buf,len);
 	cout<<json<<endl;
 	free(json);


### PR DESCRIPTION
This was necessary in my case because I was getting conflicts with bind() from using Linux sockets.  I think this is a better way to do it anyway.  Let me know what you think. 
